### PR TITLE
Add credentials: "include" to allow frontend/backend to live on different subdomains

### DIFF
--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -43,6 +43,7 @@ export async function getServerSideProps({ res, req }) {
   // Is there a better way to know the user is already logged in?
   try {
     const isAuthed = await fetch(`http://localhost:8000/api/user`, {
+      credentials: "include",
       headers: {
         accept: 'application/json',
         referer: 'http://localhost:3000/',

--- a/frontend/services/useAuth.js
+++ b/frontend/services/useAuth.js
@@ -19,6 +19,7 @@ function useProvideAuth() {
 
   const login = (email, password) => fetch('http://localhost:3000/api/login', {
     method: 'POST',
+    credentials: "include",
     headers: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
@@ -35,6 +36,7 @@ function useProvideAuth() {
 
   const logout = (email, password) => fetch('http://localhost:3000/api/logout', {
     method: 'POST',
+    credentials: "include",
     headers: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',


### PR DESCRIPTION
Hi there, 

Thanks for this repo, was really useful in getting started with next.js. I was struggling a bit with getting my CORS stuff setup as I have a subdomain for the API, but finally figured it out and thought it might be useful in the future, maybe with the todo item of environment variables for the frontend/backend.